### PR TITLE
fix: Complete AWS SDK v2 to v3 migration for Lambda functions

### DIFF
--- a/packages/cdk/lambda/casa-admin/userHomeStateHandler.ts
+++ b/packages/cdk/lambda/casa-admin/userHomeStateHandler.ts
@@ -1,7 +1,9 @@
 import { APIGatewayProxyHandler } from "aws-lambda";
-import { DynamoDB } from "aws-sdk";
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 
-const dynamoDb = new DynamoDB.DocumentClient();
+const dynamoDbClient = new DynamoDBClient({});
+const dynamoDb = DynamoDBDocumentClient.from(dynamoDbClient);
 const USER_HOME_STATES_TABLE = process.env.USER_HOME_STATES_TABLE || "";
 
 // Define default headers to include CORS
@@ -38,12 +40,12 @@ export const handler: APIGatewayProxyHandler = async (event) => {
       ":state": state,
       ":timestamp": new Date().toISOString(),
     },
-    ReturnValues: "UPDATED_NEW",
+    ReturnValues: "UPDATED_NEW" as const,
   };
 
   try {
     console.log("Updating user home state with params:", params);
-    await dynamoDb.update(params).promise();
+    await dynamoDb.send(new UpdateCommand(params));
     return {
       statusCode: 200,
       headers: defaultHeaders,
@@ -78,12 +80,12 @@ export const saveDisplayNameHandler: APIGatewayProxyHandler = async (event) => {
     UpdateExpression: "set #displayName = :displayName",
     ExpressionAttributeNames: { "#displayName": "displayName" },
     ExpressionAttributeValues: { ":displayName": displayName },
-    ReturnValues: "UPDATED_NEW",
+    ReturnValues: "UPDATED_NEW" as const,
   };
 
   try {
     console.log("Saving display name with params:", params);
-    await dynamoDb.update(params).promise();
+    await dynamoDb.send(new UpdateCommand(params));
     return {
       statusCode: 200,
       headers: defaultHeaders,

--- a/packages/cdk/lambda/casa-integrations/apns/send-push.ts
+++ b/packages/cdk/lambda/casa-integrations/apns/send-push.ts
@@ -1,9 +1,12 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
-import * as AWS from 'aws-sdk';
-import * as apn from 'node-apn';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
+import * as apn from '@parse/node-apn';
 
-const dynamodb = new AWS.DynamoDB.DocumentClient();
-const ssm = new AWS.SSM();
+const dynamoDbClient = new DynamoDBClient({});
+const dynamodb = DynamoDBDocumentClient.from(dynamoDbClient);
+const ssm = new SSMClient({});
 const TABLE_NAME = process.env.DEVICE_TOKENS_TABLE || '';
 
 // APNS credentials cache to reduce KMS calls
@@ -69,10 +72,10 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     } else {
       // Fetch credentials from SSM Parameter Store
       const [certResponse, keyResponse, teamIdResponse, keyIdResponse] = await Promise.all([
-        ssm.getParameter({ Name: '/apns/cert', WithDecryption: true }).promise(),
-        ssm.getParameter({ Name: '/apns/key', WithDecryption: true }).promise(),
-        ssm.getParameter({ Name: '/apns/team-id', WithDecryption: true }).promise(),
-        ssm.getParameter({ Name: '/apns/key-id', WithDecryption: true }).promise()
+        ssm.send(new GetParameterCommand({ Name: '/apns/cert', WithDecryption: true })),
+        ssm.send(new GetParameterCommand({ Name: '/apns/key', WithDecryption: true })),
+        ssm.send(new GetParameterCommand({ Name: '/apns/team-id', WithDecryption: true })),
+        ssm.send(new GetParameterCommand({ Name: '/apns/key-id', WithDecryption: true }))
       ]);
       
       cert = certResponse.Parameter?.Value;
@@ -214,13 +217,13 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
 }
 
 async function getDeviceTokens(userId: string): Promise<string[]> {
-  const result = await dynamodb.query({
+  const result = await dynamodb.send(new QueryCommand({
     TableName: TABLE_NAME,
     KeyConditionExpression: 'userId = :userId',
     ExpressionAttributeValues: {
       ':userId': userId
     }
-  }).promise();
+  }));
   
-  return (result.Items || []).map(item => item.deviceToken);
+  return (result.Items || []).map((item: any) => item.deviceToken);
 }

--- a/packages/cdk/lambda/casa-integrations/apns/send-push.ts
+++ b/packages/cdk/lambda/casa-integrations/apns/send-push.ts
@@ -225,5 +225,5 @@ async function getDeviceTokens(userId: string): Promise<string[]> {
     }
   }));
   
-  return (result.Items || []).map((item: any) => item.deviceToken);
+  return (result.Items || []).map((item: DeviceTokenItem) => item.deviceToken);
 }


### PR DESCRIPTION
## Overview
This PR completes the AWS SDK v2 to v3 migration by fixing the remaining Lambda functions that were still using v2 patterns.

## Changes Made

### 🔧 Lambda Function Migrations

**1. userHomeStateHandler.ts**
- ✅ Replace `DynamoDB.DocumentClient` with `DynamoDBDocumentClient`
- ✅ Update `dynamoDb.update().promise()` to `dynamoDb.send(new UpdateCommand())`
- ✅ Fix `ReturnValues` type compatibility with `as const`

**2. apns/send-push.ts**
- ✅ Replace `AWS.DynamoDB.DocumentClient` with `DynamoDBDocumentClient`
- ✅ Replace `AWS.SSM` with `SSMClient`
- ✅ Update `ssm.getParameter().promise()` to `ssm.send(new GetParameterCommand())`
- ✅ Update `dynamodb.query().promise()` to `dynamodb.send(new QueryCommand())`

## Testing
- ✅ TypeScript compilation passes without errors
- ✅ CDK build completes successfully
- ✅ All AWS SDK v3 command patterns implemented correctly

## Impact
- 🚀 Fixes runtime failures from mixed SDK versions
- 📦 Reduces Lambda bundle sizes through better tree-shaking
- 🔒 Ensures consistent security updates across all functions
- ⚡ Improves cold start performance with smaller bundles

## Related
This completes the AWS SDK modernization effort and resolves the blocking issues identified in the previous upgrade.

## Pre-merge Checklist
- [x] All TypeScript errors resolved
- [x] CDK builds successfully
- [x] No breaking changes to Lambda function signatures
- [ ] Deploy to staging environment for integration testing